### PR TITLE
Add getMeta!(...) method, enable no mixin approach

### DIFF
--- a/source/witchcraft/mixins/base.d
+++ b/source/witchcraft/mixins/base.d
@@ -2,23 +2,34 @@ module witchcraft.mixins.base;
 
 import std.meta;
 
-template TypeOfMeta(T){
+template TypeOfMeta(T)
+    {
     import witchcraft;
-
-    static if(is(T == class)) {
+    
+    static if(is(T == class))
+    {
         alias TypeOfMeta = Class;
-    } else static if(is(T == struct)) {
+    } 
+    else static if(is(T == struct)) 
+    {
         alias TypeOfMeta = Struct;
-    } else static if(is(T == interface)) {
+    }
+    else static if(is(T == interface))
+    {
         alias TypeOfMeta = InterfaceType;
-    } else static if(!is(T)) {
+    }
+    else static if(!is(T)) 
+    {
         alias TypeOfMeta = Module;
-    } else {
+    }
+    else
+    {
         static assert(false); //todo: proper error
     }
 }
 
-template ImplTypeOfMeta(T){
+template ImplTypeOfMeta(T)
+{
     import witchcraft;
     
     mixin WitchcraftClass;
@@ -28,20 +39,30 @@ template ImplTypeOfMeta(T){
     mixin WitchcraftMethod;
     mixin WitchcraftStruct;
 
-    static if(is(T == class)) {
+    static if(is(T == class))
+    {
         alias ImplTypeOfMeta = ClassMixin!(T);
-    } else static if(is(T == struct)) {
+    }
+    else static if(is(T == struct))
+    {
         alias ImplTypeOfMeta = StructMixin!(T);
-    } else static if(is(T == interface)) {
+    } 
+    else static if(is(T == interface))
+    {
         alias ImplTypeOfMeta = InterfaceTypeMixin!(T);
-    } else static if(!is(T)) {
+    }
+    else static if(!is(T))
+    {
         alias ImplTypeOfMeta = ModuleImpl!(__traits(parent, T));
-    } else {
+    }
+    else
+    {
         static assert(false); //todo: proper error
     }
 }
 
-TypeOfMeta!(T) getMeta(T)(){
+TypeOfMeta!(T) getMeta(T)()
+{
     return new ImplTypeOfMeta!(T);
 }
 

--- a/source/witchcraft/unittests/base.d
+++ b/source/witchcraft/unittests/base.d
@@ -49,7 +49,8 @@ version(unittest)
         }
     }
     
-    void testSuite(C)(C metaObject){
+    void testSuite(C)(C metaObject)
+    {
         assert(metaObject.isAggregate == true);
         assert(metaObject.isClass     == true);
         assert(metaObject.isStruct    == false);

--- a/source/witchcraft/unittests/noMixin.d
+++ b/source/witchcraft/unittests/noMixin.d
@@ -47,7 +47,8 @@ version(unittest)
         }
     }
     
-    void testSuite(C)(C metaObject){
+    void testSuite(C)(C metaObject)
+    {
         assert(metaObject.isAggregate == true);
         assert(metaObject.isClass     == true);
         assert(metaObject.isStruct    == false);

--- a/source/witchcraft/unittests/noMixin.d
+++ b/source/witchcraft/unittests/noMixin.d
@@ -1,5 +1,5 @@
 
-module witchcraft.unittests.base;
+module witchcraft.unittests.noMixin;
 
 import witchcraft;
 
@@ -20,8 +20,6 @@ version(unittest)
     @Entity
     class User
     {
-        mixin Witchcraft;
-
         @Column
         string username;
 
@@ -57,7 +55,7 @@ version(unittest)
         /+ - Classes - +/
 
         assert(metaObject.getName     == "User");
-        assert(metaObject.getFullName == "witchcraft.unittests.base.User");
+        assert(metaObject.getFullName == "witchcraft.unittests.noMixin.User");
         assert(metaObject.isAbstract  == false);
         assert(metaObject.isFinal     == false);
 
@@ -117,7 +115,7 @@ version(unittest)
 
         /+ - Methods - +/
 
-        assert(metaObject.getLocalMethodNames.isPermutation([ "getMetaType", "updateEmail" ]));
+        assert(metaObject.getLocalMethodNames == [ "updateEmail" ]);
 
         assert(metaObject.getMethods("updateEmail").empty == false);
         assert(metaObject.getMethod!(string)("updateEmail") !is null);
@@ -131,15 +129,8 @@ version(unittest)
 
 unittest
 {
-    assert(User.metaof !is null);
-    assert(getMeta!User() !is null);
-    auto metaObjectByProperty = User.metaof;
-    auto metaObjectByFunction = getMeta!User();
+    auto metaObject = getMeta!User();
+    assert(metaObject !is null);
     
-    // dirty hack to compare meta object...
-    assert(metaObjectByProperty.getFullName() == metaObjectByFunction.getFullName());
-    
-    // ...less dirty way to ensure the same behaviour
-    testSuite(metaObjectByProperty);
-    testSuite(metaObjectByFunction);
+    testSuite(metaObject);
 }

--- a/source/witchcraft/unittests/structs.d
+++ b/source/witchcraft/unittests/structs.d
@@ -12,18 +12,25 @@ version(unittest)
         string username;
         string password;
     }
+    
+    void testSuite(C)(C metaObject){
+        assert(metaObject.isAggregate == true);
+        assert(metaObject.isClass     == false);
+        assert(metaObject.isStruct    == true);
+
+        assert(metaObject.getName     == "User");
+        assert(metaObject.getFullName == "witchcraft.unittests.structs.User");
+    }
 }
 
 unittest
 {
-    auto uClass = User.metaof;
+    auto metaObjectByProperty = User.metaof;
+    auto metaObjectByFunction = getMeta!User();
 
-    assert(uClass !is null);
-
-    assert(uClass.isAggregate == true);
-    assert(uClass.isClass     == false);
-    assert(uClass.isStruct    == true);
-
-    assert(uClass.getName     == "User");
-    assert(uClass.getFullName == "witchcraft.unittests.structs.User");
+    assert(metaObjectByProperty !is null);
+    assert(metaObjectByFunction !is null);
+    
+    testSuite(metaObjectByProperty);
+    testSuite(metaObjectByFunction);
 }

--- a/source/witchcraft/unittests/structs.d
+++ b/source/witchcraft/unittests/structs.d
@@ -13,7 +13,8 @@ version(unittest)
         string password;
     }
     
-    void testSuite(C)(C metaObject){
+    void testSuite(C)(C metaObject)
+    {
         assert(metaObject.isAggregate == true);
         assert(metaObject.isClass     == false);
         assert(metaObject.isStruct    == true);


### PR DESCRIPTION
Thanks to this commit, no "mixin Witchraft" is needed - see [no mixin test](https://github.com/FilipMalczak/witchcraft/blob/master/source/witchcraft/unittests/noMixin.d).

It can be achieved by calling `getMeta!(TypeToBeAnalyzed)();`